### PR TITLE
feat: lint commits since last release

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,4 +18,5 @@ module.exports = {
     '@semantic-release/changelog',
     '@semantic-release/git',
   ],
+  verifyRelease: ['@mixmaxhq/semantic-commitlint'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
       "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
@@ -95,8 +94,7 @@
         "regenerator-runtime": {
           "version": "0.13.3",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-          "dev": true
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -206,6 +204,220 @@
       "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-8.2.0.tgz",
       "integrity": "sha512-HuwlHQ3DyVhpK9GHgTMhJXD8Zp8PGIQVpQGYh/iTrEU6TVxdRC61BxIDZvfWatCaiG617Z/U8maRAFrqFM4TqA==",
       "dev": true
+    },
+    "@commitlint/core": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/core/-/core-6.2.0.tgz",
+      "integrity": "sha1-M74jMTzkXYhhBkLKPeTcHJfMWWg=",
+      "requires": {
+        "@commitlint/format": "^6.1.3",
+        "@commitlint/lint": "^6.2.0",
+        "@commitlint/load": "^6.1.3",
+        "@commitlint/read": "^6.1.3"
+      },
+      "dependencies": {
+        "@commitlint/ensure": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-6.1.3.tgz",
+          "integrity": "sha1-gTtYyf364VNRty/mRqFi69tx6io=",
+          "requires": {
+            "lodash.camelcase": "4.3.0",
+            "lodash.kebabcase": "4.1.1",
+            "lodash.snakecase": "4.1.1",
+            "lodash.startcase": "4.4.0",
+            "lodash.upperfirst": "4.3.1"
+          }
+        },
+        "@commitlint/execute-rule": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-6.1.3.tgz",
+          "integrity": "sha1-SJKOc27xXocQ0zKhXHyJlVXk4Qs=",
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "@commitlint/format": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-6.1.3.tgz",
+          "integrity": "sha1-QUuQSKmvVFh9qWIicXujMjR6veM=",
+          "requires": {
+            "babel-runtime": "^6.23.0",
+            "chalk": "^2.0.1"
+          }
+        },
+        "@commitlint/is-ignored": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-6.1.3.tgz",
+          "integrity": "sha1-icm5ZKTWIoh1pXnCv1UtADc0t+g=",
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "@commitlint/lint": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-6.2.0.tgz",
+          "integrity": "sha1-148hl0W3c2LhuBTV9M7C7MMmZhk=",
+          "requires": {
+            "@commitlint/is-ignored": "^6.1.3",
+            "@commitlint/parse": "^6.1.3",
+            "@commitlint/rules": "^6.2.0",
+            "babel-runtime": "^6.23.0",
+            "lodash.topairs": "4.3.0"
+          }
+        },
+        "@commitlint/load": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-6.1.3.tgz",
+          "integrity": "sha1-G+QHETl5WPMWz0BXepyHmhbwClQ=",
+          "requires": {
+            "@commitlint/execute-rule": "^6.1.3",
+            "@commitlint/resolve-extends": "^6.1.3",
+            "babel-runtime": "^6.23.0",
+            "cosmiconfig": "^4.0.0",
+            "lodash.merge": "4.6.1",
+            "lodash.mergewith": "4.6.1",
+            "lodash.pick": "4.4.0",
+            "lodash.topairs": "4.3.0",
+            "resolve-from": "4.0.0"
+          }
+        },
+        "@commitlint/message": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-6.1.3.tgz",
+          "integrity": "sha1-XgRzMwyIcBYBDExWJwcjuAARRdI="
+        },
+        "@commitlint/parse": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-6.1.3.tgz",
+          "integrity": "sha1-/x5NksJ81naBK7a512zYhTwNlAc=",
+          "requires": {
+            "conventional-changelog-angular": "^1.3.3",
+            "conventional-commits-parser": "^2.1.0"
+          }
+        },
+        "@commitlint/read": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-6.1.3.tgz",
+          "integrity": "sha1-n52NtQ+/Z/MACSFlftbvrbjPnxo=",
+          "requires": {
+            "@commitlint/top-level": "^6.1.3",
+            "@marionebl/sander": "^0.6.0",
+            "babel-runtime": "^6.23.0",
+            "git-raw-commits": "^1.3.0"
+          }
+        },
+        "@commitlint/resolve-extends": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-6.1.3.tgz",
+          "integrity": "sha1-9F/P5Dhg4F4489lNVMrtfdqkHiU=",
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "lodash.merge": "4.6.1",
+            "lodash.omit": "4.5.0",
+            "require-uncached": "^1.0.3",
+            "resolve-from": "^4.0.0",
+            "resolve-global": "^0.1.0"
+          }
+        },
+        "@commitlint/rules": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-6.2.0.tgz",
+          "integrity": "sha1-k5H2WhZVKCIEjUWjOrbON0aG4Gs=",
+          "requires": {
+            "@commitlint/ensure": "^6.1.3",
+            "@commitlint/message": "^6.1.3",
+            "@commitlint/to-lines": "^6.1.3",
+            "babel-runtime": "^6.23.0"
+          }
+        },
+        "@commitlint/to-lines": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-6.1.3.tgz",
+          "integrity": "sha1-erFqAsrtjapH6Vkmm5YWRhCinQw="
+        },
+        "@commitlint/top-level": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-6.1.3.tgz",
+          "integrity": "sha1-Em3LbeFnY0LGnNQiYUg/RHhUcpk=",
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "conventional-changelog-angular": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+          "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+          "requires": {
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
+          }
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+          "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+          "requires": {
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0",
+            "trim-off-newlines": "^1.0.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
+          }
+        },
+        "is-text-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+          "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+          "requires": {
+            "text-extensions": "^1.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        },
+        "resolve-global": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
+          "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
+          "requires": {
+            "global-dirs": "^0.1.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "text-extensions": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+          "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
     },
     "@commitlint/ensure": {
       "version": "8.2.0",
@@ -485,7 +697,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
       "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.3",
         "mkdirp": "^0.5.1",
@@ -508,6 +719,268 @@
       "resolved": "https://registry.npmjs.org/@mixmaxhq/prettier-config/-/prettier-config-1.0.0.tgz",
       "integrity": "sha512-2laBND7BpObmEd6JXP69cbAbG4ay9Z9m1y5q0Sc+VKVJS1rl7eZxT+Qasm7NxPyQgBKIC290BYLGkt7lsTIgLA==",
       "dev": true
+    },
+    "@mixmaxhq/semantic-commitlint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mixmaxhq/semantic-commitlint/-/semantic-commitlint-1.0.0.tgz",
+      "integrity": "sha512-LqjDL9X5i7q1PjihlRUVPXizb01DAjlVD0pYxCLBil9BhQ/NImiE+fOuIK4UgMQaBxOymwRAd30Fhl4Dx1p8+Q==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@commitlint/cli": "^6.0.2",
+        "@commitlint/core": "^6.0.2",
+        "@semantic-release/error": "^2.1.0"
+      },
+      "dependencies": {
+        "@commitlint/cli": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-6.2.0.tgz",
+          "integrity": "sha1-svgZDrCMzXjuplEUuGTzxl7KRmo=",
+          "requires": {
+            "@commitlint/format": "^6.1.3",
+            "@commitlint/lint": "^6.2.0",
+            "@commitlint/load": "^6.1.3",
+            "@commitlint/read": "^6.1.3",
+            "babel-polyfill": "6.26.0",
+            "chalk": "2.3.1",
+            "get-stdin": "5.0.1",
+            "lodash.merge": "4.6.1",
+            "lodash.pick": "4.4.0",
+            "meow": "4.0.0"
+          }
+        },
+        "@commitlint/ensure": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-6.1.3.tgz",
+          "integrity": "sha1-gTtYyf364VNRty/mRqFi69tx6io=",
+          "requires": {
+            "lodash.camelcase": "4.3.0",
+            "lodash.kebabcase": "4.1.1",
+            "lodash.snakecase": "4.1.1",
+            "lodash.startcase": "4.4.0",
+            "lodash.upperfirst": "4.3.1"
+          }
+        },
+        "@commitlint/execute-rule": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-6.1.3.tgz",
+          "integrity": "sha1-SJKOc27xXocQ0zKhXHyJlVXk4Qs=",
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "@commitlint/format": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-6.1.3.tgz",
+          "integrity": "sha1-QUuQSKmvVFh9qWIicXujMjR6veM=",
+          "requires": {
+            "babel-runtime": "^6.23.0",
+            "chalk": "^2.0.1"
+          }
+        },
+        "@commitlint/is-ignored": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-6.1.3.tgz",
+          "integrity": "sha1-icm5ZKTWIoh1pXnCv1UtADc0t+g=",
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "@commitlint/lint": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-6.2.0.tgz",
+          "integrity": "sha1-148hl0W3c2LhuBTV9M7C7MMmZhk=",
+          "requires": {
+            "@commitlint/is-ignored": "^6.1.3",
+            "@commitlint/parse": "^6.1.3",
+            "@commitlint/rules": "^6.2.0",
+            "babel-runtime": "^6.23.0",
+            "lodash.topairs": "4.3.0"
+          }
+        },
+        "@commitlint/load": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-6.1.3.tgz",
+          "integrity": "sha1-G+QHETl5WPMWz0BXepyHmhbwClQ=",
+          "requires": {
+            "@commitlint/execute-rule": "^6.1.3",
+            "@commitlint/resolve-extends": "^6.1.3",
+            "babel-runtime": "^6.23.0",
+            "cosmiconfig": "^4.0.0",
+            "lodash.merge": "4.6.1",
+            "lodash.mergewith": "4.6.1",
+            "lodash.pick": "4.4.0",
+            "lodash.topairs": "4.3.0",
+            "resolve-from": "4.0.0"
+          }
+        },
+        "@commitlint/message": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-6.1.3.tgz",
+          "integrity": "sha1-XgRzMwyIcBYBDExWJwcjuAARRdI="
+        },
+        "@commitlint/parse": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-6.1.3.tgz",
+          "integrity": "sha1-/x5NksJ81naBK7a512zYhTwNlAc=",
+          "requires": {
+            "conventional-changelog-angular": "^1.3.3",
+            "conventional-commits-parser": "^2.1.0"
+          }
+        },
+        "@commitlint/read": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-6.1.3.tgz",
+          "integrity": "sha1-n52NtQ+/Z/MACSFlftbvrbjPnxo=",
+          "requires": {
+            "@commitlint/top-level": "^6.1.3",
+            "@marionebl/sander": "^0.6.0",
+            "babel-runtime": "^6.23.0",
+            "git-raw-commits": "^1.3.0"
+          }
+        },
+        "@commitlint/resolve-extends": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-6.1.3.tgz",
+          "integrity": "sha1-9F/P5Dhg4F4489lNVMrtfdqkHiU=",
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "lodash.merge": "4.6.1",
+            "lodash.omit": "4.5.0",
+            "require-uncached": "^1.0.3",
+            "resolve-from": "^4.0.0",
+            "resolve-global": "^0.1.0"
+          }
+        },
+        "@commitlint/rules": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-6.2.0.tgz",
+          "integrity": "sha1-k5H2WhZVKCIEjUWjOrbON0aG4Gs=",
+          "requires": {
+            "@commitlint/ensure": "^6.1.3",
+            "@commitlint/message": "^6.1.3",
+            "@commitlint/to-lines": "^6.1.3",
+            "babel-runtime": "^6.23.0"
+          }
+        },
+        "@commitlint/to-lines": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-6.1.3.tgz",
+          "integrity": "sha1-erFqAsrtjapH6Vkmm5YWRhCinQw="
+        },
+        "@commitlint/top-level": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-6.1.3.tgz",
+          "integrity": "sha1-Em3LbeFnY0LGnNQiYUg/RHhUcpk=",
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.2.0"
+          }
+        },
+        "conventional-changelog-angular": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+          "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+          "requires": {
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
+          }
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+          "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+          "requires": {
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0",
+            "trim-off-newlines": "^1.0.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
+          }
+        },
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+        },
+        "is-text-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+          "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+          "requires": {
+            "text-extensions": "^1.0.0"
+          }
+        },
+        "meow": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+          "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        },
+        "resolve-global": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
+          "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
+          "requires": {
+            "global-dirs": "^0.1.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "text-extensions": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+          "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -938,7 +1411,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1052,7 +1524,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
@@ -1062,8 +1533,7 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
       }
     },
@@ -1071,7 +1541,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1569,8 +2038,7 @@
     "core-js": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
-      "dev": true
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1650,7 +2118,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -2223,8 +2690,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -2806,7 +3272,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-      "dev": true,
       "requires": {
         "dargs": "^4.0.1",
         "lodash.template": "^4.0.2",
@@ -2819,7 +3284,6 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -2852,7 +3316,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
       "requires": {
         "ini": "^1.3.4"
       }
@@ -3272,8 +3735,7 @@
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3416,7 +3878,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3524,8 +3985,12 @@
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -3557,22 +4022,56 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
+    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -3582,7 +4081,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -3593,6 +4091,11 @@
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
+    "lodash.topairs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+      "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -3602,6 +4105,11 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+    },
+    "lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984="
     },
     "longest": {
       "version": "2.0.1",
@@ -3795,7 +4303,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3803,8 +4310,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -6960,8 +7466,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -7475,8 +7980,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7521,11 +8025,45 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "caller-path": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        }
+      }
     },
     "resolve": {
       "version": "1.12.0",
@@ -7618,7 +8156,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -8185,8 +8722,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/mixmaxhq/semantic-release-config#readme",
   "dependencies": {
+    "@mixmaxhq/semantic-commitlint": "^1.0.0",
     "@semantic-release/changelog": "^3.0.5",
     "@semantic-release/commit-analyzer": "^6.3.1",
     "@semantic-release/git": "^7.0.17",


### PR DESCRIPTION
This is a better way to ensure semantic-release understands all the commits. Our existing `@mixmaxhq/commitlint-jenkins` is best suited for use on feature branches/in pull requests and doesn't have enough information to lint the whole release.