### PR TITLE
fix: filler commit to trigger patch semantic-release

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,5 +18,5 @@ module.exports = {
     '@semantic-release/changelog',
     '@semantic-release/git',
   ],
-  verifyRelease: ['@mixmaxhq/semantic-commitlint'],
+  verifyRelease: ['@mixmaxhq/semantic-commitlint'], // HACK(shil) comment for release
 };


### PR DESCRIPTION
This is just to publish a new patch version with the results of https://github.com/mixmaxhq/semantic-release-config/pull/27. There's probably a better way to do this.