### PR TITLE
feat(config): generate patch releases for nonstandard types

### DIFF
--- a/config/conventionalcommits-release-rules.js
+++ b/config/conventionalcommits-release-rules.js
@@ -1,6 +1,26 @@
 module.exports = [
   {
+    type: 'build',
+    release: 'patch',
+  },
+  {
+    type: 'chore',
+    release: 'patch',
+  },
+  {
+    type: 'ci',
+    release: 'patch',
+  },
+  {
     type: 'improvement',
     release: 'minor',
+  },
+  {
+    type: 'refactor',
+    release: 'patch',
+  },
+  {
+    type: 'revert',
+    release: 'patch',
   },
 ];


### PR DESCRIPTION
#### Changes Made
According to this module's README.md, it supports these types: https://github.com/commitizen/conventional-commit-types/blob/master/index.json

However, since we use our release config to extend [the commit-analyzer defaults](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js), many of these types don't generate associated releases. I've been bitten by this a few times, mostly on chore commits.

This commit introduces releases for ci, build, chore, revert, and refactor commits to avoid this problem.

#### Potential Risks
We start releasing spurious versions. The whole team should probably agree on these release types.

#### Test Plan
Hmm. npm link this config somewhere when releasing a patch version...?

#### Checklist
- [ ] I've increased test coverage -> N/A
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
