### PR TITLE
Name the released package in the semantic-release success comment

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -45,7 +45,15 @@ module.exports = {
     ],
     '@semantic-release/changelog',
     '@semantic-release/npm',
-    '@semantic-release/github',
+    [
+      '@semantic-release/github',
+      {
+        successComment:
+          ':tada: This PR is included in **${nextRelease.gitTag}** :tada:\n\n' +
+          'The release is available on ' +
+          '[GitHub release](${releases.find((release) => /github\\.com/.test(release.url))?.url}).',
+      },
+    ],
     '@semantic-release/git',
   ],
 };


### PR DESCRIPTION
## 📚 Context/Description Behind The Change

The `package` preset's `@semantic-release/github` step posts the default success comment ("🎉 This PR is included in version X 🎉") on every PR included in a release. In multi-package repos that comment doesn't say *which* package released — you have to hover the links to find out, which is noisy when these comments get mirrored elsewhere.

This sets a custom `successComment` that leads with the package, using `${nextRelease.gitTag}`:

- Monorepo repos (per-lib `tagFormat`, e.g. `<package>/v${version}`) → the comment names the package and version.
- Single-package repos (default `tagFormat`) → reads `v1.2.3`, same info as before.

No dependency or behavior change — comment text only. The GitHub-release link is preserved via a null-safe `releases.find(...)?.url` lookup.

## 🚨 Potential Risks & What To Monitor After Deployment

- Shared config: affects every repo consuming the `package` preset. The change is additive (comment text), uses long-standing `@semantic-release/github` `successComment` template variables, and needs no semantic-release version bump — safe across current consumers.
- `service`/`module` presets untouched.

## 🧑‍🔬 How Has This Been Tested?

- [x] `npm run lint` passes; config parses; the github plugin is a configured tuple.
- [x] Downstream positional destructuring still resolves `github`/`git` correctly.
- [x] End-to-end: exercised the real `@semantic-release/github` `success` step against a throwaway repo (npm publishing disabled) with a monorepo-style `tagFormat`; the posted comment rendered the package-qualified tag as intended.

## 🚚 Release Plan

- [x] Normal deploy (publishes a new minor of `@mixmaxhq/semantic-release-config`); consumers pick it up via their `^4` range.
