### PR TITLE
Restore automated releases (public release workflow + release environment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,9 @@ on:
 jobs:
   checks:
     uses: mixmaxhq/github-workflows-public/.github/workflows/checks.yml@main
+
+  release:
+    needs: checks
+    if: github.event_name == 'push'
+    uses: mixmaxhq/github-workflows-public/.github/workflows/release.yml@main
+    secrets: inherit


### PR DESCRIPTION
## 📚 Context

Automated releases for this repo were dropped when CI was migrated to a checks-only workflow; releases have been manual since. This restores automated `semantic-release` on merge to `master`.

It adds a `release` job that calls the shared **public** release workflow, gated to `master`:

```yaml
jobs:
  checks:
    uses: mixmaxhq/github-workflows-public/.github/workflows/checks.yml@main

  release:
    needs: checks
    uses: mixmaxhq/github-workflows-public/.github/workflows/release.yml@main
    secrets: inherit
```

Publishing credentials are supplied from a branch-scoped **`release` environment** rather than plain repo secrets. This is the GitHub-recommended way to publish from a **public** repository: environment secrets are withheld from fork PRs and gated to the protected `master` branch, so they're only ever available to the release job on a trusted push.

## ✅ Prerequisites (done)

The `release` environment and both secrets (`NPM_TOKEN`, `GH_TOKEN`) are now provisioned — see comment below.

1. **Create a `release` environment** (Settings → Environments) with:
   - Deployment branches: **Protected branches only**
   - No required reviewers, no wait timer
2. **Add environment secrets** to `release`:
   - `NPM_TOKEN` — an npm automation token with publish access
   - `GH_TOKEN` — a token that can push the `chore(release)` commit to protected `master` (a PAT/app token with a branch-protection bypass, or a `master` exception for the release identity). The default `GITHUB_TOKEN` will otherwise be blocked by branch protection.



## 🚨 Risk

- Release tooling only — no runtime/service code, and trivially revertible.
- Secrets live in the protected-branch `release` environment and are not exposed to fork PRs (safe for a public repo).
- The first post-merge run is a no-op (`semantic-release` finds nothing releasable since `v4.1.0`); the next `feat:`/`fix:` merge releases automatically.

## 🧑‍🔬 How Has This Been Tested?

- [x] `ci.yml` validates; uses only the public shared workflows.
- [x] `release` environment + `NPM_TOKEN`/`GH_TOKEN` provisioned. Remaining: confirm a `master` push triggers the release job and (once a releasable commit lands) publishes + comments correctly.

