### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mixmaxhq/semantic-release-config.git"
+    "url": "git+https://github.com/mixmaxhq/semantic-release-config.git"
   },
   "keywords": [
     "semantic-release"


### PR DESCRIPTION
## Summary

- replace the package repository metadata SSH URL with the public HTTPS GitHub URL
- keep runtime code, dependencies, package version, homepage, bugs metadata, license, and package contents unchanged

## Why

`@mixmaxhq/semantic-release-config@4.1.0` currently publishes:

```json
"repository": {
  "type": "git",
  "url": "git+ssh://git@github.com/mixmaxhq/semantic-release-config.git"
}
```

This public package points to a public repository, so consumers and registry tooling should not need GitHub SSH credentials to resolve the source repository link. The `git+https://` form is the appropriate public read-only URL.

## Validation

- `npm view @mixmaxhq/semantic-release-config@4.1.0 name version repository homepage bugs license --json`
- `node -e "const p=require('./package.json'); if(p.repository.url!=='git+https://github.com/mixmaxhq/semantic-release-config.git') throw new Error('bad repository url'); if(p.bugs.url!=='https://github.com/mixmaxhq/semantic-release-config/issues') throw new Error('bugs changed'); if(p.homepage!=='https://github.com/mixmaxhq/semantic-release-config#readme') throw new Error('homepage changed'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage},null,2))"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
